### PR TITLE
Fixing units for interest rate chart.

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -73,7 +73,7 @@ func InterestRateChart(invs []*Investment) TimeseriesChart {
 		case i == 0:
 			t.value = 0
 		default:
-			t.value = float32(s.Balance-s.Change-summs[i-1].Balance) / float32(s.Change+summs[i-1].Balance)
+			t.value = float32(s.Balance-s.Change-summs[i-1].Balance) / float32(s.Change+summs[i-1].Balance) * 100.0
 		}
 		chart = append(chart, t)
 	}


### PR DESCRIPTION
It was in range [0,1], but it is more readable and consumed by humans in the range [0,100]%.

Graphs already add the '%' unit, so all that was missing was multiplying by 100.

(related to #2)
